### PR TITLE
Containerized HTTP Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-slim
+
+WORKDIR /usr/src/app
+COPY package*.json ./
+
+RUN npm install
+
+# Copy app source code to the working dir.
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["node", "dist/http.js"]

--- a/README.md
+++ b/README.md
@@ -146,10 +146,75 @@ npm run build
 npm start
 ```
 
+## Docker
+
+This project includes a `Dockerfile` to build and run the Swarm MCP server as a containerized HTTP service.
+
+### Building the Docker Image
+
+To build the Docker image, run the following command from the project root:
+
+```bash
+docker build -t swarm-mcp-server .
+```
+
+### Running the Docker Container
+
+To run the server, use the `docker run` command. The server is exposed on port `3000`.
+
+```bash
+docker run --name swarm-mcp -p 3000:3000 swarm-mcp-server
+```
+
+#### Configuration with Environment Variables
+
+To configure the server, pass environment variables to the container using the `-e` flag. This is necessary to connect to your own Bee node or use features like Swarm Feeds.
+
+```bash
+docker run -p 3000:3000 \
+  -e BEE_API_URL="http://localhost:1633" \
+  -e BEE_BATCH_ID="your_batch_id_here" \
+  -e BEE_FEED_PK="your_private_key_here" \
+  swarm-mcp-server
+```
+
+### Testing with cURL
+
+You can test if the HTTP server is running correctly by sending a `tools/list` request using `curl`. This command asks the server to list all available tools.
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+-H "Content-Type: application/json" \
+-H "Accept: application/json, text/event-stream" \
+-d '{
+  "jsonrpc": "2.0",
+  "method": "tools/list",
+  "id": 1
+}'
+```
+
+A successful response will be a JSON object containing a list of the server's tools.
+
 ## Using with MCP Clients
 
-The Swarm MCP server communicates via standard input/output (stdio) following the MCP protocol. To use it with MCP clients:
+The server supports two connection methods:
 
-1. Start the server
-2. Connect your MCP-compatible client to the server
-3. Use the provided MCP tools (`upload_text`, `download_text`, `upload_file`, `upload_folder`, `download_folder`)
+### 1. HTTP Connection (Docker)
+
+When running the server in Docker, it operates as an HTTP service. To connect your MCP client, you must use one that supports connecting to a remote server via URL.
+
+- **Server URL**: `http://localhost:3000/mcp`
+
+In your client's settings, add a new remote/custom connector and provide this URL.
+
+### 2. Stdio Connection (Local)
+
+For local development or with clients that manage their own server subprocesses, you can run the server directly. In this mode, the client communicates over `stdio`.
+
+For detailed instructions on how to configure your MCP client for stdio, please refer to the [Swarm MCP Client Setup guide](./docs/mcp-client-setup.md).
+
+```bash
+# Build and run the stdio server
+npm run build
+npm start
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,13 @@
       "dependencies": {
         "@ethereumjs/wallet": "^10.0.0",
         "@ethersphere/bee-js": "^9.4.1",
-        "@modelcontextprotocol/sdk": "^1.13.2"
+        "@modelcontextprotocol/sdk": "^1.13.2",
+        "cors": "^2.8.5",
+        "express": "^5.1.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "jest": "^30.0.3",
         "nodemon": "^3.1.10",
@@ -1395,6 +1399,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1433,6 +1500,13 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.0.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
@@ -1441,6 +1515,43 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,13 @@
   "dependencies": {
     "@ethereumjs/wallet": "^10.0.0",
     "@ethersphere/bee-js": "^9.4.1",
-    "@modelcontextprotocol/sdk": "^1.13.2"
+    "@modelcontextprotocol/sdk": "^1.13.2",
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.3",
     "nodemon": "^3.1.10",

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import express, { Request, Response } from 'express';
+import cors from 'cors';
+import { SwarmMCPServer } from './mcp-service';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+const host = process.env.HOST || '0.0.0.0';
+
+const app = express();
+
+// Enable CORS for all routes
+app.use(cors());
+app.use(express.json());
+
+// Handle all MCP requests on the /mcp endpoint
+app.all('/mcp', async (req: Request, res: Response) => {
+  console.error(`[${req.method}] Handling request for ${req.path}`);
+  try {
+    // In stateless mode, create a new server and transport for each request
+    const swarmMCPServer = new SwarmMCPServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // Enforce stateless behavior
+    });
+
+    // Clean up when the request is closed
+    res.on('close', () => {
+      transport.close();
+      swarmMCPServer.server.close();
+      console.error('Request closed, resources released.');
+    });
+
+    // Connect the server and transport, then handle the request
+    await swarmMCPServer.server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null,
+      });
+    }
+  }
+});
+
+// Start the server
+app.listen(port, host, () => {
+  console.error(`Swarm MCP Server running on http://${host}:${port}`);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 
-import swarmMCPServer from './mcp-service';
+import { SwarmMCPServer } from './mcp-service';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-// Run the Swarm MCP Server
-console.error('Starting Swarm MCP Server...');
-swarmMCPServer.run().catch((error) => {
+async function main() {
+  console.error('Starting Swarm MCP Server on stdio...');
+  const swarmMCPServer = new SwarmMCPServer();
+  const transport = new StdioServerTransport();
+  await swarmMCPServer.server.connect(transport);
+  console.error('Swarm MCP Server running on stdio');
+}
+
+main().catch((error) => {
   console.error('Failed to start Swarm MCP Server:', error);
   process.exit(1);
 });

--- a/src/mcp-service.ts
+++ b/src/mcp-service.ts
@@ -2,7 +2,6 @@
  * MCP Service implementation for handling blob data operations with Bee (Swarm)
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { Bee } from '@ethersphere/bee-js';
 import config from './config';
@@ -16,9 +15,9 @@ import { downloadFolder, DownloadFolderArgs } from './tools/download-folder';
 /**
  * Swarm MCP Server class
  */
-class SwarmMCPServer {
-  private server: McpServer;
-  private bee: Bee;
+export class SwarmMCPServer {
+  public server: McpServer;
+  private readonly bee: Bee;
 
   constructor() {
     console.error('[Setup] Initializing Swarm MCP server...');
@@ -201,11 +200,5 @@ class SwarmMCPServer {
     });
   }
 
-  async run() {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
-    console.error('Swarm MCP server running on stdio');
-  }
 }
 
-export default new SwarmMCPServer();


### PR DESCRIPTION
Adds an HTTP interface to the Swarm MCP server, allowing it to run as a persistent, containerized service.

- Creates an Express-based server to handle MCP requests over HTTP.
- Includes a Dockerfile for building and running the server in a container.
- Supports configuration via environment variables for Bee API details.
- Updates documentation to include instructions for Docker, HTTP client connection, and `curl` test commands.