### PR TITLE
feat: add gsoc_send tool

### DIFF
--- a/src/mcp-service.ts
+++ b/src/mcp-service.ts
@@ -60,6 +60,7 @@ import { revokeFeedAccess } from "./tools/revoke_feed_access";
 import { fetchFromFeedWithAct } from "./tools/fetch_from_feed_with_act";
 import { publishMarketplaceFeed } from "./tools/publish_marketplace_feed";
 import { fetchMarketplaceFeed } from "./tools/fetch_marketplace_feed";
+import { gsocSend } from "./tools/gsoc_send";
 
 // Model types
 import type { UploadFileArgs } from "./tools/upload_file/models";
@@ -89,6 +90,7 @@ import type { RevokeFeedAccessArgs } from "./tools/revoke_feed_access/models";
 import type { FetchFromFeedWithActArgs } from "./tools/fetch_from_feed_with_act/models";
 import type { PublishMarketplaceFeedArgs } from "./tools/publish_marketplace_feed/models";
 import type { FetchMarketplaceFeedArgs } from "./tools/fetch_marketplace_feed/models";
+import type { GsocSendArgs } from "./tools/gsoc_send/models";
 
 // Zod schemas
 import {
@@ -122,6 +124,7 @@ import {
   fetchFromFeedWithActSchema,
   publishMarketplaceFeedSchema,
   fetchMarketplaceFeedSchema,
+  gsocSendSchema,
 } from "./schemas/zod-schemas";
 import { TASK_POLL_INTERVAL } from "./tasks/constants";
 import { uploadFile } from "./tools/upload_file";
@@ -503,6 +506,11 @@ export class SwarmMCPServer {
               );
             }
 
+            case "gsoc_send": {
+              const validArgs = gsocSendSchema.parse(args);
+              return gsocSend(validArgs as GsocSendArgs, this.bee);
+            }
+
             default:
               throw new McpError(
                 ErrorCode.MethodNotFound,
@@ -739,6 +747,7 @@ export class SwarmMCPServer {
           "fetch_from_feed_with_act",
           "publish_marketplace_feed",
           "fetch_marketplace_feed",
+          "gsoc_send",
         ];
         tools = tools.filter((item) => !nodeOnlyTools.includes(item.name));
       }

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -857,6 +857,58 @@ export const SwarmToolsSchema = [
     execution: { taskSupport: "forbidden" },
   },
   {
+    name: "gsoc_send",
+    title: "Send GSOC message",
+    description:
+      "Sends a GSOC message via bee.gsocSend. Caller provides a mined GSOC signer (resourceId = 32-byte hex private key) and a human-readable topic (hashed into an Identifier internally). The message body is decoded per `encoding` (utf8 default; base64 / hex also supported). Returns the chunk reference plus the signerAddress a subscriber would plug into gsocSubscribe. Requires a full Bee node — gateways refuse GSOC writes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        message: {
+          type: "string",
+          description: "Message body. Decoded per `encoding`.",
+        },
+        resourceId: {
+          type: "string",
+          description:
+            "32-byte hex private key, mined for the target overlay (the GSOC signer). Same value a subscriber uses on the receiving end. 0x-prefix accepted.",
+        },
+        topic: {
+          type: "string",
+          description:
+            "Human-readable topic label. Hashed into a 32-byte Identifier via Identifier.fromString. The subscriber must use the same string.",
+        },
+        encoding: {
+          type: "string",
+          enum: ["utf8", "base64", "hex"],
+          default: "utf8",
+          description:
+            "How to decode `message` bytes. Default utf8. Use base64 or hex for binary payloads.",
+        },
+        postageBatchId: {
+          type: "string",
+          description:
+            "Postage stamp ID for the chunk. Falls back to AUTO_ASSIGN_STAMP if unset.",
+        },
+      },
+      required: ["message", "resourceId", "topic"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        reference: { type: "string" },
+        bytesSent: { type: "number" },
+        encoding: { type: "string" },
+        topic: { type: "string" },
+        topicHex: { type: "string" },
+        signerAddress: { type: "string" },
+        message: { type: "string" },
+      },
+      required: ["reference", "bytesSent", "signerAddress"],
+    },
+    execution: { taskSupport: "forbidden" },
+  },
+  {
     name: "query_upload_progress",
     title: "Query upload progress",
     description:

--- a/src/schemas/zod-schemas.ts
+++ b/src/schemas/zod-schemas.ts
@@ -343,3 +343,15 @@ export const fetchFromFeedWithActSchema = z.object({
   filePath: z.string().optional(),
   actTimestamp: z.coerce.number().optional(),
 });
+
+export const gsocSendSchema = z.object({
+  message: z
+    .string()
+    .min(1, { message: "Missing required parameter: message." }),
+  resourceId: z
+    .string()
+    .min(1, { message: "Missing required parameter: resourceId." }),
+  topic: z.string().min(1, { message: "Missing required parameter: topic." }),
+  encoding: z.enum(["utf8", "base64", "hex"]).optional().default("utf8"),
+  postageBatchId: z.string().optional(),
+});

--- a/src/tools/gsoc_send/index.ts
+++ b/src/tools/gsoc_send/index.ts
@@ -1,0 +1,152 @@
+/**
+ * MCP Tool: gsoc_send
+ *
+ * Sends a GSOC message with a caller-provided signer (mined GSOC resource
+ * key) and topic. The topic is a human-readable string; it's hashed into a
+ * 32-byte identifier via Identifier.fromString (keccak under the hood).
+ *
+ * Flow:
+ *   1. Resolve postage batch (falls back to AUTO_ASSIGN_STAMP).
+ *   2. Decode the message per `encoding` (utf8 default; base64 and hex also
+ *      supported for binary payloads).
+ *   3. Call bee.gsocSend(stamp, signer, identifier, bytes).
+ *   4. Return the chunk reference + the signerAddress a subscriber would
+ *      plug into gsocSubscribe.
+ *
+ * Note: "Only full nodes can accept GSOC messages." Gateway Bee nodes will
+ * error — that's why this tool is in the nodeOnlyTools filter.
+ */
+import { Bee, Identifier, PrivateKey } from "@ethersphere/bee-js";
+import {
+  errorHasStatus,
+  getErrorMessage,
+  getResponseWithStructuredContent,
+  getToolErrorResponse,
+  ToolResponse,
+} from "../../utils";
+import { getUploadPostageBatchId } from "../../utils/upload-stamp";
+import { GsocSendArgs, GsocSendEncoding } from "./models";
+import { BAD_REQUEST_STATUS } from "../../constants";
+
+function stripHexPrefix(value: string): string {
+  return value.startsWith("0x") || value.startsWith("0X")
+    ? value.slice(2)
+    : value;
+}
+
+function decodeMessage(
+  raw: string,
+  encoding: GsocSendEncoding
+): { bytes: Buffer; error?: string } {
+  try {
+    if (encoding === "utf8") {
+      return { bytes: Buffer.from(raw, "utf8") };
+    }
+    if (encoding === "hex") {
+      const hex = stripHexPrefix(raw);
+      if (!/^[0-9a-fA-F]*$/.test(hex)) {
+        return {
+          bytes: Buffer.alloc(0),
+          error: "message is not valid hex",
+        };
+      }
+      if (hex.length % 2 !== 0) {
+        return {
+          bytes: Buffer.alloc(0),
+          error: "hex message must have even length",
+        };
+      }
+      return { bytes: Buffer.from(hex, "hex") };
+    }
+    if (encoding === "base64") {
+      if (!/^[A-Za-z0-9+/=_-]*$/.test(raw)) {
+        return {
+          bytes: Buffer.alloc(0),
+          error: "message is not valid base64",
+        };
+      }
+      return { bytes: Buffer.from(raw, "base64") };
+    }
+    return {
+      bytes: Buffer.alloc(0),
+      error: `unknown encoding: ${String(encoding)}`,
+    };
+  } catch (e) {
+    return {
+      bytes: Buffer.alloc(0),
+      error: `failed to decode message (${encoding}): ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+export async function gsocSend(
+  args: GsocSendArgs,
+  bee: Bee
+): Promise<ToolResponse> {
+  if (!args.message) {
+    return getToolErrorResponse("Missing required parameter: message.");
+  }
+  if (!args.resourceId) {
+    return getToolErrorResponse(
+      "Missing required parameter: resourceId (32-byte hex private key mined for the target overlay)."
+    );
+  }
+  if (!args.topic) {
+    return getToolErrorResponse("Missing required parameter: topic.");
+  }
+  const encoding: GsocSendEncoding = args.encoding ?? "utf8";
+
+  const { bytes, error: decodeError } = decodeMessage(args.message, encoding);
+  if (decodeError) return getToolErrorResponse(decodeError);
+  if (bytes.length === 0) {
+    return getToolErrorResponse("Decoded message is empty.");
+  }
+
+  const { postageBatchId, error } = await getUploadPostageBatchId(
+    args.postageBatchId,
+    bee
+  );
+  if (error !== null) return getToolErrorResponse(error);
+  if (postageBatchId === null)
+    return getToolErrorResponse("No postage batch id.");
+
+  let signer: PrivateKey;
+  try {
+    signer = new PrivateKey(stripHexPrefix(args.resourceId));
+  } catch (e) {
+    return getToolErrorResponse(
+      `Invalid resourceId: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+  const signerAddress = signer.publicKey().address();
+
+  const identifier = Identifier.fromString(args.topic);
+
+  try {
+    const result = await bee.gsocSend(
+      postageBatchId,
+      signer,
+      identifier,
+      bytes
+    );
+    return getResponseWithStructuredContent({
+      reference: result.reference.toHex(),
+      bytesSent: bytes.length,
+      encoding,
+      topic: args.topic,
+      topicHex: identifier.toHex(),
+      signerAddress: signerAddress.toHex(),
+      message: "GSOC message sent.",
+    });
+  } catch (err) {
+    const body = getErrorMessage(err);
+    if (errorHasStatus(err, BAD_REQUEST_STATUS)) {
+      return getToolErrorResponse(
+        `Bee rejected the GSOC send: ${body || (err instanceof Error ? err.message : String(err))}`
+      );
+    }
+    return getToolErrorResponse(
+      `Unable to send GSOC message: ${body || (err instanceof Error ? err.message : String(err))}. Note: GSOC requires a full Bee node; gateway nodes refuse.`
+    );
+  }
+}

--- a/src/tools/gsoc_send/models.ts
+++ b/src/tools/gsoc_send/models.ts
@@ -1,0 +1,9 @@
+export type GsocSendEncoding = "utf8" | "base64" | "hex";
+
+export interface GsocSendArgs {
+  message: string;
+  resourceId: string;
+  topic: string;
+  encoding?: GsocSendEncoding;
+  postageBatchId?: string;
+}


### PR DESCRIPTION
Wraps bee.gsocSend for MCP callers. Inputs:
- message      text body, decoded per `encoding`
- resourceId   32-byte hex private key (mined GSOC signer; 0x-prefix ok)
- topic        human-readable string, hashed into an Identifier via
               Identifier.fromString (keccak internally)
- encoding     utf8 | base64 | hex (default utf8) for binary-safe payloads
- postageBatchId optional; AUTO_ASSIGN_STAMP falls back

Returns { reference, bytesSent, encoding, topic, topicHex, signerAddress, message }. signerAddress (publicKey().address()) is what a subscriber plugs into gsocSubscribe, closing the loop for callers testing both ends.

Registered in SwarmToolsSchema + nodeOnlyTools. GSOC writes require a full Bee node -- gateways refuse -- so the gateway-mode filter drops it.