### PR TITLE
fix: Upload single file folder with index document

### DIFF
--- a/src/tools/upload_folder/index.ts
+++ b/src/tools/upload_folder/index.ts
@@ -13,7 +13,7 @@ import { getUploadPostageBatchId } from "../../utils/upload-stamp";
 import { UploadFolderArgs } from "./models";
 import { BAD_REQUEST_STATUS } from "../../constants";
 
-import { updateUploadFolderTaskStatus } from "./utils";
+import { collectFilesRelative, updateUploadFolderTaskStatus } from "./utils";
 import { TaskManager } from "../../tasks/task-manager";
 import { CreateTaskModel, TaskState } from "../../tasks/models";
 
@@ -61,6 +61,14 @@ export async function uploadFolder(
 
   const deferred = true; // Folders are always deferred if possible/requested
   options.deferred = deferred;
+
+  // Single-file collections return raw manifest bytes from the Bee node unless an
+  // index document is set, so auto-detect and set it to avoid garbled downloads.
+  const allFiles = await collectFilesRelative(args.folderPath);
+  if (allFiles.length === 1) {
+    options.indexDocument = allFiles[0];
+  }
+
   let message = "Folder successfully uploaded to Swarm";
 
   let tagId: string | undefined = undefined;

--- a/src/tools/upload_folder/utils.ts
+++ b/src/tools/upload_folder/utils.ts
@@ -1,4 +1,6 @@
 import { Bee } from "@ethersphere/bee-js";
+import { readdir } from "fs/promises";
+import path from "path";
 import {
   ExtendedTask,
   TaskState,
@@ -56,3 +58,23 @@ export const updateUploadFolderTaskStatus: UpdateStatusFunction = async (
     );
   }
 };
+
+
+export const collectFilesRelative = async (
+  dir: string,
+  relative = ""
+): Promise<string[]> => {
+  const entries = await readdir(path.join(dir, relative), {
+    withFileTypes: true,
+  });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryRelative = relative ? `${relative}/${entry.name}` : entry.name;
+    if (entry.isFile()) {
+      files.push(entryRelative);
+    } else if (entry.isDirectory()) {
+      files.push(...(await collectFilesRelative(dir, entryRelative)));
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
Allow the correct download of single file folders. By setting `indexDocument` when uploading the folder, the download would yield just the file inside the folder.