### PR TITLE
fix: Don't rely on LLM to do base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Upload a file to Swarm.
 
 **Parameters:**
 
-- `data`: base64 encoded file content or file path.
+- `data`: File content or file path.
 - `isPath`: Wether the data parameter is a path.
 - `redundancyLevel`: (Optional) Redundancy level for fault tolerance (higher values provide better fault tolerance but increase storage overhead). 0 - none, 1 - medium, 2 - strong, 3 - insane, 4 - paranoid.
 - `postageBatchId`: (Optional) The postage stamp batch ID which will be used to perform the upload, if it is provided.

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -190,7 +190,7 @@ export const SwarmToolsSchema = [
       properties: {
         data: {
           type: "string",
-          description: "base64 encoded file content or file path",
+          description: "File content or file path.",
         },
         isPath: {
           type: "boolean",

--- a/src/tools/upload_file/index.ts
+++ b/src/tools/upload_file/index.ts
@@ -29,11 +29,11 @@ export async function uploadFile(
   taskManager?: TaskManager,
   createTaskModel?: CreateTaskModel
 ): Promise<ToolResponse | CreateTaskResult> {
+  // return getToolErrorResponse("Echo  " + args.data);
+
   if (!args.data) {
     return getToolErrorResponse("Missing required parameter: data.22");
   }
-
-  // return getToolErrorResponse(`args.data: ${args.data}`);
 
   const { postageBatchId, error } = await getUploadPostageBatchId(
     args.postageBatchId,
@@ -65,7 +65,7 @@ export async function uploadFile(
     }
     name = path.basename(args.data);
   } else {
-    binaryData = Buffer.from(args.data, "base64");
+    binaryData = Buffer.from(args.data);
   }
 
   const redundancyLevel = args.redundancyLevel;

--- a/src/tools/upload_file/index.ts
+++ b/src/tools/upload_file/index.ts
@@ -29,8 +29,6 @@ export async function uploadFile(
   taskManager?: TaskManager,
   createTaskModel?: CreateTaskModel
 ): Promise<ToolResponse | CreateTaskResult> {
-  // return getToolErrorResponse("Echo  " + args.data);
-
   if (!args.data) {
     return getToolErrorResponse("Missing required parameter: data.22");
   }


### PR DESCRIPTION
Removed the reliance on the MCP Client to do the base64 encoding of file content for **upload_file** tool. If it doesn't do it, the resulting file content is unreadable.